### PR TITLE
Add Insight Agent Lite skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Insight Agent Lite
+
+A lightweight multi-role AI assistant for overseas stock research. Designed for local PCs with 8GB VRAM running a quantized Llama 3 8B model via [Ollama](https://github.com/ollama/ollama).
+
+This repository provides a minimal skeleton implementation, featuring a Gradio-based chat UI and a placeholder agent using LangChain-compatible patterns.
+
+## Requirements
+- Python 3.10+
+- The `ollama` runtime with `llama3:8b` model installed
+
+Install dependencies:
+```bash
+pip install -r requirements.txt
+```
+
+## Running
+```bash
+python app.py
+```
+
+This launches a local Gradio interface where you can chat with the agent, upload PDF files, and configure API keys.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,49 @@
+import gradio as gr
+from insight_agent_lite.agent import InsightAgentLite
+
+agent = InsightAgentLite()
+
+# Simple in-memory stores for files and API keys
+uploaded_files = []
+api_keys = {"stock": "", "search": ""}
+
+
+def handle_chat(message, history):
+    response = agent.answer(message)
+    return response
+
+
+def upload_pdf(files):
+    uploaded_files.extend(files)
+    return [f.name for f in uploaded_files]
+
+
+def save_stock_key(key):
+    api_keys["stock"] = key
+    return "Saved"
+
+
+def save_search_key(key):
+    api_keys["search"] = key
+    return "Saved"
+
+
+with gr.Blocks() as demo:
+    gr.Markdown("# Insight Agent Lite")
+    chat = gr.ChatInterface(handle_chat)
+    with gr.Accordion("Files & API Keys", open=False):
+        gr.Markdown("### Upload PDF Reports")
+        file_uploader = gr.File(label="Upload", file_types=[".pdf"],
+                                file_count="multiple")
+        file_uploader.upload(upload_pdf, file_uploader, gr.State())
+        file_list = gr.Markdown("No files uploaded")
+        file_uploader.change(lambda fs: "\n".join([f.name for f in uploaded_files]),
+                             None, file_list)
+        gr.Markdown("### API Keys")
+        stock_key = gr.Textbox(label="Stock Data API Key", type="password")
+        stock_key.submit(save_stock_key, stock_key)
+        search_key = gr.Textbox(label="Web Search API Key", type="password")
+        search_key.submit(save_search_key, search_key)
+
+if __name__ == "__main__":
+    demo.launch()

--- a/insight_agent_lite/agent.py
+++ b/insight_agent_lite/agent.py
@@ -1,0 +1,35 @@
+class InsightAgentLite:
+    """Simple multi-role agent skeleton."""
+
+    def __init__(self):
+        # In-memory cache for previous Q&A
+        self.memory = {}
+
+    def _search_memory(self, question: str):
+        return self.memory.get(question)
+
+    def _store_memory(self, question: str, answer: str):
+        self.memory[question] = answer
+
+    def orchestrate(self, question: str) -> str:
+        """Plan tool usage. Placeholder implementation."""
+        # In a real system, this would use an LLM to create a plan.
+        plan = ["search_web", "search_stock"]
+        return f"Planned steps: {', '.join(plan)}"
+
+    def reason(self, gathered_info: str) -> str:
+        """Generate final answer. Placeholder implementation."""
+        # In a real system, this would run a second LLM pass.
+        return f"\nBased on gathered info:\n{gathered_info}\n\n(analysis...)"
+
+    def answer(self, question: str) -> str:
+        cached = self._search_memory(question)
+        if cached:
+            return cached
+
+        plan = self.orchestrate(question)
+        # Placeholder tool execution
+        gathered_info = f"Executed: {plan}"
+        answer = self.reason(gathered_info)
+        self._store_memory(question, answer)
+        return answer

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+gradio
+ollama
+langchain


### PR DESCRIPTION
## Summary
- add minimal README with instructions
- create skeleton multi-role agent class
- build simple Gradio UI with PDF upload and API key sections
- add requirements file

## Testing
- `python -m py_compile app.py insight_agent_lite/agent.py`

------
https://chatgpt.com/codex/tasks/task_e_686d31dec698832a821fd58d2ddf0eeb